### PR TITLE
Fix migration file that was behind

### DIFF
--- a/prisma/migrations/20241020033257_init/migration.sql
+++ b/prisma/migrations/20241020033257_init/migration.sql
@@ -71,7 +71,7 @@ CREATE TABLE "CodeTemplate" (
     "title" TEXT NOT NULL,
     "description" TEXT NOT NULL,
     "code" TEXT NOT NULL,
-    "language" INTEGER NOT NULL,
+    "language" TEXT NOT NULL,
     "userId" INTEGER NOT NULL,
     CONSTRAINT "CodeTemplate_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
 );


### PR DESCRIPTION
**Summary**
Forgot to run the migration after the int->string change in the CodeTemplate schema. 
This is just a quick fix for that.