### PR TITLE
Add execution logic for Python and C

### DIFF
--- a/pages/api/execute/index.ts
+++ b/pages/api/execute/index.ts
@@ -1,0 +1,24 @@
+import { ExecutionResult } from "@/src/execute/executor";
+import { PythonExecutor } from "@/src/execute/python-executor";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type ResponseData = { message: string } | ExecutionResult;
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<ResponseData>
+) {
+    let { language, code, stdin, timeout } = req.body;
+    if (!language || language != "Python") {
+        res.status(400).json({ message: "Only Python is supported right now" });
+        return;
+    }
+
+    let executor = new PythonExecutor();
+    const execution_result = await executor.execute({
+        code: code,
+        stdin: stdin,
+        timeout: timeout,
+    });
+    res.status(200).json(execution_result);
+}

--- a/pages/api/execute/index.ts
+++ b/pages/api/execute/index.ts
@@ -1,5 +1,5 @@
 import { ExecutionResult } from "@/src/execute/executor";
-import { PythonExecutor } from "@/src/execute/python-executor";
+import { ExecutorFactory } from "@/src/execute/executor-factory";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 type ResponseData = { message: string } | ExecutionResult;
@@ -9,12 +9,12 @@ export default async function handler(
     res: NextApiResponse<ResponseData>
 ) {
     let { language, code, stdin, timeout } = req.body;
-    if (!language || language != "Python") {
-        res.status(400).json({ message: "Only Python is supported right now" });
+    let executor = ExecutorFactory.fromLanguage(language);
+    if (!executor) {
+        res.status(400).json({ message: "The language is not supported." });
         return;
     }
 
-    let executor = new PythonExecutor();
     const execution_result = await executor.execute({
         code: code,
         stdin: stdin,

--- a/src/execute/C-executor.ts
+++ b/src/execute/C-executor.ts
@@ -1,0 +1,57 @@
+import * as path from "path";
+import * as os from "os";
+
+import {
+    cleanupFile,
+    createTempFile,
+    getUniqueFileName,
+    spawnHelper,
+} from "./utils";
+import { ExecutionOptions, ExecutionResult, Executor } from "./executor";
+
+export class CExecutor implements Executor {
+    /**
+     * Compile and execute the C file using gcc as a compiler.
+     */
+    async execute(options: ExecutionOptions): Promise<ExecutionResult> {
+        const tempFilePrefix = getUniqueFileName();
+        const tempDir = os.tmpdir();
+
+        const tempFilePath = await createTempFile(
+            tempFilePrefix + ".c",
+            options.code
+        );
+        const executablePath = path.join(tempDir, tempFilePrefix);
+
+        let { stdout, stderr, code } = await spawnHelper({
+            command: "gcc",
+            args: ["-o", executablePath, tempFilePath],
+        });
+
+        if (code !== 0) {
+            // compilation unsuccessful; don't try running executable
+            try {
+                await cleanupFile(tempFilePath);
+            } catch (error) {
+                console.error(`Error deleting .c file: ${error}`);
+            }
+            return { stdout, stderr };
+        }
+
+        let { stdout: runStdout, stderr: runStderr } = await spawnHelper(
+            { command: executablePath },
+            options.stdin
+        );
+
+        stdout += runStdout;
+        stderr += runStderr;
+
+        try {
+            await cleanupFile(executablePath);
+            await cleanupFile(tempFilePath);
+        } catch (error) {
+            console.error(`Error deleting files: ${error}`);
+        }
+        return { stdout, stderr };
+    }
+}

--- a/src/execute/executor-factory.ts
+++ b/src/execute/executor-factory.ts
@@ -1,0 +1,21 @@
+// a simple functional "factory" to create an Executor
+
+import { CExecutor } from "./C-executor";
+import { PythonExecutor } from "./python-executor";
+
+export class ExecutorFactory {
+    /**
+     * Return an Executor of the given language, or null if the language is not supported.
+     * @param language the language to be executed
+     */
+    static fromLanguage(language: string | undefined) {
+        switch (language) {
+            case "Python":
+                return new PythonExecutor();
+            case "C":
+                return new CExecutor();
+            default:
+                return null;
+        }
+    }
+}

--- a/src/execute/executor.ts
+++ b/src/execute/executor.ts
@@ -1,0 +1,50 @@
+// Defines components of the executor use case's interface that interacts with the controller in ~/pages/api/execute.
+
+/**
+ * Represents the options required to execute a piece of code.
+ */
+export interface ExecutionOptions {
+    /**
+     * The source code to be executed.
+     */
+    code: string;
+
+    /**
+     * (Optional) The standard input to be provided to the code during execution.
+     * Useful for programs that require user input.
+     */
+    stdin?: string;
+
+    /**
+     * (Optional) The maximum time allowed for code execution, specified in milliseconds.
+     * If the execution exceeds this time, it should be terminated to prevent indefinite runs.
+     */
+    timeout?: number; // in milliseconds (not needed for part 1)
+}
+
+/**
+ * Represents the result of executing a piece of code.
+ */
+export interface ExecutionResult {
+    /**
+     * The standard output produced by the executed code.
+     * Contains any text that the code writes to the standard output stream.
+     */
+    stdout: string;
+
+    /**
+     * The standard error produced by the executed code.
+     * Contains any error messages or logs that the code writes to the standard error stream.
+     */
+    stderr: string;
+}
+
+/**
+ * Defines the contract for executors that can run code.
+ */
+export interface Executor {
+    /**
+     * Executes the provided code with the given options.
+     */
+    execute(options: ExecutionOptions): Promise<ExecutionResult>;
+}

--- a/src/execute/executor.ts
+++ b/src/execute/executor.ts
@@ -1,6 +1,11 @@
 // Defines components of the executor use case's interface that interacts with the controller in ~/pages/api/execute.
 
 /**
+ * Set of supporting languages for code execution.
+ */
+export const supportedLanguages = new Set<string>(["Python", "C"]); // TODO: add C++, Java, and JavaScript
+
+/**
  * Represents the options required to execute a piece of code.
  */
 export interface ExecutionOptions {

--- a/src/execute/executor.ts
+++ b/src/execute/executor.ts
@@ -1,11 +1,6 @@
 // Defines components of the executor use case's interface that interacts with the controller in ~/pages/api/execute.
 
 /**
- * Set of supporting languages for code execution.
- */
-export const supportedLanguages = new Set<string>(["Python", "C"]); // TODO: add C++, Java, and JavaScript
-
-/**
  * Represents the options required to execute a piece of code.
  */
 export interface ExecutionOptions {

--- a/src/execute/python-executor.ts
+++ b/src/execute/python-executor.ts
@@ -1,10 +1,11 @@
 import { ExecutionOptions, ExecutionResult, Executor } from "./executor";
 import { spawn } from "child_process";
-import { cleanupFile, createTempFile } from "./utils";
+import { cleanupFile, createTempFile, getUniqueFileName } from "./utils";
 
 export class PythonExecutor implements Executor {
     async execute(options: ExecutionOptions): Promise<ExecutionResult> {
-        const tempFilePath = await createTempFile("py", options.code);
+        const tempFileName = getUniqueFileName() + ".py";
+        const tempFilePath = await createTempFile(tempFileName, options.code);
 
         return await new Promise<ExecutionResult>((resolve, reject) => {
             // Spawn the Python process

--- a/src/execute/python-executor.ts
+++ b/src/execute/python-executor.ts
@@ -1,0 +1,50 @@
+import { ExecutionOptions, ExecutionResult, Executor } from "./executor";
+import { spawn } from "child_process";
+import { cleanupFile, createTempFile } from "./utils";
+
+export class PythonExecutor implements Executor {
+    async execute(options: ExecutionOptions): Promise<ExecutionResult> {
+        const tempFilePath = await createTempFile("py", options.code);
+
+        return await new Promise<ExecutionResult>((resolve, reject) => {
+            // Spawn the Python process
+            const pythonProcess = spawn("python3", [tempFilePath]);
+
+            let stdout = "";
+            let stderr = "";
+
+            // Capture stdout
+            pythonProcess.stdout.on("data", (data) => {
+                stdout += data.toString();
+            });
+
+            // Capture stderr
+            pythonProcess.stderr.on("data", (data) => {
+                stderr += data.toString();
+            });
+
+            // Handle errors in spawning the process
+            pythonProcess.on("error", (err) => {
+                reject(
+                    new Error(`Failed to start Python process: ${err.message}`)
+                );
+            });
+
+            // Handle process exit
+            pythonProcess.on("close", async (code, signal) => {
+                cleanupFile(tempFilePath).catch((error) => {
+                    console.error(`Error deleting temp file: ${error.message}`);
+                });
+                resolve({ stdout, stderr });
+            });
+
+            // Write to stdin if provided
+            if (options.stdin) {
+                pythonProcess.stdin.write(options.stdin);
+            }
+
+            // Close stdin to indicate no more data
+            pythonProcess.stdin.end();
+        });
+    }
+}

--- a/src/execute/utils.ts
+++ b/src/execute/utils.ts
@@ -4,7 +4,7 @@ import { promises as fs } from "fs";
 import { spawn, SpawnOptionsWithoutStdio } from "child_process";
 import { randomBytes } from 'crypto';
 
-// helpers for the execute use case
+// This file contains helpers for the execute use case.
 
 type SpawnArgs = {
     command: string;
@@ -63,6 +63,10 @@ export async function spawnHelper(
     });
 }
 
+/**
+ * Return a (very likely to be) unique file name. 
+ * Used by other functions to prevent naming conflicts for temp files.
+ */
 export function getUniqueFileName() {
     const timestamp = Date.now();
     const randomStr = randomBytes(8).toString('hex'); // Generates a 16-character hex string

--- a/src/execute/utils.ts
+++ b/src/execute/utils.ts
@@ -1,22 +1,83 @@
 import * as path from "path";
 import * as os from "os";
 import { promises as fs } from "fs";
+import { spawn, SpawnOptionsWithoutStdio } from "child_process";
+import { randomBytes } from 'crypto';
 
 // helpers for the execute use case
 
+type SpawnArgs = {
+    command: string;
+    args?: readonly string[];
+    options?: SpawnOptionsWithoutStdio;
+};
+
+type SpawnReturn = {
+    stdout: string;
+    stderr: string;
+    code: number | null;
+    signal: NodeJS.Signals | null;
+};
+
 /**
- * Creates a temporary file with the specified extension and writes the provided data to it.
- * @returns a promise containing the path of the newly created file.
+ * Spawn a process with possible stdin redirected and capturing stderr and stdout.
+ * { command, args, options } are defined in the same way as in the spawn documentation.
+ */
+export async function spawnHelper(
+    { command, args, options }: SpawnArgs,
+    stdin?: string
+): Promise<SpawnReturn> {
+    return await new Promise<SpawnReturn>((resolve, reject) => {
+        const process = spawn(command, args, options);
+
+        let stdout = "";
+        let stderr = "";
+
+        // Capture stdout
+        process.stdout.on("data", (data) => {
+            stdout += data.toString();
+        });
+
+        // Capture stderr
+        process.stderr.on("data", (data) => {
+            stderr += data.toString();
+        });
+
+        // Handle errors in spawning the process
+        process.on("error", (err) => {
+            reject(new Error(`Failed to start process: ${err.message}`));
+        });
+
+        // Handle process exit
+        process.on("close", async (code, signal) => {
+            resolve({ stdout, stderr, code, signal });
+        });
+
+        // Write to stdin if provided
+        if (stdin) {
+            process.stdin.write(stdin);
+        }
+
+        // Close stdin to indicate no more data
+        process.stdin.end();
+    });
+}
+
+export function getUniqueFileName() {
+    const timestamp = Date.now();
+    const randomStr = randomBytes(8).toString('hex'); // Generates a 16-character hex string
+    return `${timestamp}-${randomStr}`;
+}
+
+/**
+ * Creates a temporary file with the specified name and writes the provided data to it.
+ * @returns a promise containing the path of the newly created file if it succeeds.
  */
 export async function createTempFile(
-    extension: string,
+    tempFileName: string,
     data: string
 ): Promise<string> {
     const tempDir = os.tmpdir();
-    const uniqueSuffix = `${Date.now()}-${Math.random()
-        .toString(36)
-        .substring(2, 15)}`;
-    const tempFileName = `temp_script_${uniqueSuffix}.${extension}`;
     const tempFilePath = path.join(tempDir, tempFileName);
 
     try {

--- a/src/execute/utils.ts
+++ b/src/execute/utils.ts
@@ -101,5 +101,6 @@ export async function cleanupFile(path: string): Promise<void> {
         console.log(`File ${path} deleted successfully.`);
     } catch (error) {
         console.log(error);
+        throw error;
     }
 }

--- a/src/execute/utils.ts
+++ b/src/execute/utils.ts
@@ -1,0 +1,44 @@
+import * as path from "path";
+import * as os from "os";
+import { promises as fs } from "fs";
+
+// helpers for the execute use case
+
+/**
+ * Creates a temporary file with the specified extension and writes the provided data to it.
+ * @returns a promise containing the path of the newly created file.
+ */
+export async function createTempFile(
+    extension: string,
+    data: string
+): Promise<string> {
+    const tempDir = os.tmpdir();
+    const uniqueSuffix = `${Date.now()}-${Math.random()
+        .toString(36)
+        .substring(2, 15)}`;
+    const tempFileName = `temp_script_${uniqueSuffix}.${extension}`;
+    const tempFilePath = path.join(tempDir, tempFileName);
+
+    try {
+        await fs.writeFile(tempFilePath, data);
+    } catch (error) {
+        console.error(`Error writing to file ${tempFilePath}:`, error);
+        throw error; // Re-throw the error after logging it
+    }
+
+    return tempFilePath;
+}
+
+/**
+ * Deletes the specified file from the filesystem.
+ * @param {string} filePath - The path to the file that needs to be deleted.
+ * @returns {Promise<void>} - A promise that resolves when the file is successfully deleted.
+ */
+export async function cleanupFile(path: string): Promise<void> {
+    try {
+        await fs.unlink(path);
+        console.log(`File ${path} deleted successfully.`);
+    } catch (error) {
+        console.log(error);
+    }
+}


### PR DESCRIPTION
**Summary**
Implemented the `POST /api/execute` endpoint that allows visitors (unauthenticated and authenticated) to execute code in Python and C.

**Review Notes**
Along with the logic, please review the file structure and organization of the code and do let me know if you have any suggestions/improvement.

**Testing**
Tested through simply sending 4 sample requests that seemed to have the expected behaviour as shown in the images below. 

 Link to download a Postman collection that I used to test this [Scriptorium.json](https://github.com/user-attachments/files/17453185/Scriptorium.json)

- Test 1: Python (success) ✅
![image](https://github.com/user-attachments/assets/a6225691-c6d0-405a-a293-506e6692ebd8)

- Test 2: Python (error) ✅
![image](https://github.com/user-attachments/assets/45d5ee6c-8c4a-419d-b8fa-6eb63ce2e69a)

- Test 4: C (success) ✅
![image](https://github.com/user-attachments/assets/4dcbc795-0686-45ae-9ee7-55572e998ddd)

- Test 4: C (error) ✅
![image](https://github.com/user-attachments/assets/0e64de2c-1428-44f7-abe1-9d0f56455b03)


Issues to be closed by this: 
- https://github.com/Scriptorium-CSC309/web/issues/11
- https://github.com/Scriptorium-CSC309/web/issues/12