### PR TITLE
Implemented fetch for comments

### DIFF
--- a/Scriptorium.postman_collection.json
+++ b/Scriptorium.postman_collection.json
@@ -693,6 +693,32 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "fetch-comment",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:3000/api/comments?postId=2",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "3000",
+							"path": [
+								"api",
+								"comments"
+							],
+							"query": [
+								{
+									"key": "postId",
+									"value": "2"
+								}
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		}

--- a/pages/api/comments/index.ts
+++ b/pages/api/comments/index.ts
@@ -1,11 +1,14 @@
 import createCommentsInteractor from "@/src/comments/create-comments";
+import getCommentsInteractor from "@/src/comments/get-comments";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 function handler(req: NextApiRequest, res: NextApiResponse) {
     if (req.method === "POST") {
-        createCommentsInteractor(req, res);
+        return createCommentsInteractor(req, res);
+    } else if (req.method === "GET") {
+        return getCommentsInteractor(req, res);
     } else {
-        res.setHeader("Allow", ["GET", "PUT"]);
+        res.setHeader("Allow", ["GET", "POST"]);
         res.status(405).end(`Method ${req.method} Not Allowed`);
     }
 }

--- a/src/comments/get-comments.ts
+++ b/src/comments/get-comments.ts
@@ -1,0 +1,94 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import prisma from "@/prisma";
+import Joi from "joi";
+import { Prisma } from "@prisma/client";
+
+type Error = {
+    error: string;
+};
+
+type CommentData = {
+    comments: any[];
+    total: number;
+    page: number;
+    pageSize: number;
+};
+
+const getCommentsSchema = Joi.object({
+    page: Joi.number().integer().min(1).default(1),
+    pageSize: Joi.number().integer().min(1).max(100).default(10),
+    postId: Joi.number().integer().required(),
+    sortBy: Joi.string().valid("valued", "controversial").optional(),
+});
+
+async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<CommentData | Error>
+) {
+    // TODO: consider if comments of hidden blogposts should be visible. Currently they are.
+
+    if (req.method !== "GET") {
+        res.status(405).json({ error: "Method not allowed" });
+        return;
+    }
+
+    try {
+        const { value, error } = getCommentsSchema.validate(req.query);
+        if (error) {
+            res.status(400).json({ error: error.details[0].message });
+            return;
+        }
+
+        const { page, pageSize, postId, sortBy } = value;
+
+        // Construct the 'where' clause to filter comments by postId
+        const where: Prisma.CommentWhereInput = { postId, isHidden: false };
+
+        // Calculate pagination parameters
+        const skip = (page - 1) * pageSize;
+        const take = pageSize;
+
+        // Handle sorting
+        let orderBy: Prisma.CommentOrderByWithRelationInput[] = [{ postedAt: "desc" }];
+
+        if (sortBy === "valued") {
+            // Sort by upvotes descending and downvotes ascending
+            orderBy = [
+                { upvotes: "desc" },
+                { downvotes: "asc" },
+            ];
+        } else if (sortBy === "controversial") {
+            // Approximate controversy by sorting by upvotes and downvotes descending
+            orderBy = [
+                { upvotes: "desc" },
+                { downvotes: "desc" },
+            ];
+        }
+
+        // Fetch the total count of comments for pagination
+        const total = await prisma.comment.count({ where });
+
+        // Fetch the comments with pagination, filtering, and sorting
+        const comments = await prisma.comment.findMany({
+            where,
+            include: {
+                user: true, // Include user details
+            },
+            skip,
+            take,
+            orderBy,
+        });
+
+        return res.status(200).json({
+            comments,
+            total,
+            page,
+            pageSize,
+        });
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ error: "Internal Server Error" });
+    }
+}
+
+export default handler;


### PR DESCRIPTION
**Summary**

Implemented a paginated fetch on comments under the endpoint `GET /api/comments`.

**Review Notes**

Currently comments under hidden posts are visible. There are no user stories that say this should _not_ be possible, but we may decide to change this in the future.

**Testing**

Tested using the new Postman request.

- Test 1: ![image](https://github.com/user-attachments/assets/d0c735b2-7afb-49e3-b176-62bc851fec2d)

Issues to be closed by this PR: 
- https://github.com/Scriptorium-CSC309/web/issues/41
