### PR TITLE
Allow admins to hide comments

### DIFF
--- a/pages/api/comments/[id]/index.ts
+++ b/pages/api/comments/[id]/index.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import hideCommentHandler from "@/src/comments/[id]/hide-comment";
+
+function handler(req: NextApiRequest, res: NextApiResponse) {
+    if (req.method === "PATCH") {
+        return hideCommentHandler(req, res);
+    } else {
+        res.setHeader("Allow", ["PATCH"]);
+        return res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+}
+
+export default handler;

--- a/src/comments/[id]/hide-comment.ts
+++ b/src/comments/[id]/hide-comment.ts
@@ -1,0 +1,72 @@
+import type { NextApiResponse } from "next";
+import prisma from "@/prisma";
+import Joi from "joi";
+import { withAuth } from "@/src/auth/middleware"; 
+import { AuthenticatedRequest } from "../../auth/utils";
+
+type Error = {
+    error: string;
+};
+
+type SuccessResponse = {
+    message: string;
+};
+
+const hideCommentSchema = Joi.object({
+    id: Joi.number().integer().required(),
+});
+
+const bodySchema = Joi.object({
+    isHidden: Joi.boolean().required(),
+});
+
+async function handler(
+    req: AuthenticatedRequest,
+    res: NextApiResponse<SuccessResponse | Error>
+) {
+    if (req.method !== "PATCH") {
+        return res.status(405).json({ error: "Method not allowed" });
+    }
+
+    // Validate the 'id' parameter from the route
+    const { value: params, error: paramsError } = hideCommentSchema.validate(
+        req.query,
+        { convert: true }
+    );
+    if (paramsError) {
+        return res.status(400).json({ error: paramsError.details[0].message });
+    }
+
+    // Validate the 'isHidden' parameter from the body
+    const { value: body, error: bodyError } = bodySchema.validate(req.body);
+    if (bodyError) {
+        return res.status(400).json({ error: bodyError.details[0].message });
+    }
+
+    const { id } = params;
+    const { isHidden } = body;
+    const userId = Number(req.user.userId);
+
+    try {
+        // Fetch the comment to verify its existence
+        const comment = await prisma.comment.findUnique({
+            where: { id },
+        });
+
+        if (!comment) {
+            return res.status(404).json({ error: "Comment not found" });
+        }
+
+        await prisma.comment.update({
+            where: { id },
+            data: { isHidden: isHidden },
+        });
+
+        return res.status(200).json({ message: "Comment hidden successfully" });
+    } catch (err) {
+        console.error("Error hiding comment:", err);
+        return res.status(500).json({ error: "Internal Server Error" });
+    }
+}
+
+export default withAuth(handler, { admin: true });

--- a/src/comments/[id]/hide-comment.ts
+++ b/src/comments/[id]/hide-comment.ts
@@ -62,7 +62,7 @@ async function handler(
             data: { isHidden: isHidden },
         });
 
-        return res.status(200).json({ message: "Comment hidden successfully" });
+        return res.status(200).json({ message: "Comment visibility set successfully" });
     } catch (err) {
         console.error("Error hiding comment:", err);
         return res.status(500).json({ error: "Internal Server Error" });


### PR DESCRIPTION
**Summary**

Admins can now successfully hide/unhide comments using the `PATH /api/comments/[id]` endpoint and providing a boolen `isHidden` in the request body.

**Testing**

Tested using the new endpoint added to Postman. It is not refleced here but I think we should be able to access a shared collection now. Also added some documentation to the endpoint there.

Issues to be closed by this PR: 
- https://github.com/Scriptorium-CSC309/web/issues/48