### PR TITLE
Added refresh token logic to authentication

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,12 +2,12 @@
 
 # Environment variables declared in this file are automatically made available to Prisma.
 # See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
-
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-
 DATABASE_URL="file:./database_url.db"
+
 # Use a strong secret key.
 # Can Execute the following in a terminal to generate a strong key
 # Type node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-JWT_SECRET="JWT_SECRET"  # Use a strong, random secret key
+JWT_SECRET="JWT_SECRET"  
+REFRESH_TOKEN_SECRET="REFRESH_TOKEN_SECRET"

--- a/pages/api/auth/refresh/index.ts
+++ b/pages/api/auth/refresh/index.ts
@@ -1,0 +1,38 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import jwt from "jsonwebtoken";
+
+const jwtSecret = process.env.JWT_SECRET!;
+const refreshTokenSecret = process.env.REFRESH_TOKEN_SECRET!;
+
+export default async function refreshToken(
+    req: NextApiRequest,
+    res: NextApiResponse
+) {
+    if (req.method !== "POST") {
+        res.status(405).json({ error: `Method ${req.method} not allowed` });
+        return;
+    }
+
+    const { refreshToken } = req.body;
+
+    if (!refreshToken) {
+        return res.status(400).json({ error: "Refresh token is required" });
+    }
+
+    try {
+        // Verify refresh token
+        const decoded = jwt.verify(refreshToken, refreshTokenSecret) as any;
+
+        // Issue new access token
+        const accessToken = jwt.sign(
+            { id: decoded.id, isAdmin: decoded.isAdmin },
+            jwtSecret,
+            { expiresIn: "15m" }
+        );
+
+        return res.status(200).json({ accessToken });
+    } catch (error) {
+        console.log(error);
+        return res.status(401).json({ error: "Invalid refresh token" });
+    }
+}

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -38,7 +38,7 @@ export function withAuth<T>(
                 return;
             }
 
-            const authReq = req as AuthenticatedRequest
+            const authReq = req as AuthenticatedRequest;
             authReq.user = {
                 userId: decoded.id,
                 isAdmin: decoded.isAdmin,
@@ -50,8 +50,12 @@ export function withAuth<T>(
                 res as NextApiResponse<T>
             );
         } catch (error) {
-            console.log(error);
-            res.status(401).json({ error: "Invalid token" });
+            if (error instanceof jwt.TokenExpiredError) {
+                res.status(401).json({ error: "Access token expired" });
+            } else {
+                console.log(error);
+                res.status(401).json({ error: "Invalid token" });
+            }
             return;
         }
     };


### PR DESCRIPTION
**Summary**

Added a new `POST /api/auth/refresh` endpoint that can refresh an expired access token. Also, modified the login and middleware logic to work properly with refresh tokens and give users more tailored errors.

**Review Notes**

The middleware interfaces remain unchanged, so API handler won't need refactoring.

**Testing**

I used an access token with a short expiration time (30s) to test it out and it refreshed appropriately when sending a request to  `POST /api/auth/refresh`.

Issues to be closed by this PR: 
- https://github.com/Scriptorium-CSC309/web/issues/60