### PR TITLE
Users now see hidden comments iff they authored it

### DIFF
--- a/pages/api/hello.ts
+++ b/pages/api/hello.ts
@@ -1,16 +1,15 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import { withAuth } from "@/src/auth/middleware";
-import type { NextApiRequest, NextApiResponse } from "next";
+import { withAuth, withOptionalAuth } from "@/src/auth/middleware";
+import { AuthenticatedRequest, OptionallyAuthenticatedRequest } from "@/src/auth/utils";
+import type { NextApiResponse } from "next";
 
 type Data = {
-  name: string;
-};
+    userId: string;
+    isAdmin: boolean;
+} | null;
 
-function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<Data>,
-) {
-  res.status(200).json({ name: "John Doe" });
+async function handler(req: OptionallyAuthenticatedRequest, res: NextApiResponse<Data>) {
+    return res.status(200).json(req.user);
 }
 
-export default withAuth(handler, { admin: true });
+export default withOptionalAuth(handler);

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -1,13 +1,23 @@
 import { NextApiRequest, NextApiResponse, NextApiHandler } from "next";
 import jwt from "jsonwebtoken";
-import { AuthenticatedHandler, AuthenticatedRequest } from "./utils";
+import {
+    AuthenticatedHandler,
+    AuthenticatedRequest,
+    OptionallyAuthenticatedHandler,
+    OptionallyAuthenticatedRequest,
+} from "./utils";
 
 const JWT_SECRET = process.env.JWT_SECRET!;
 
 /**
  * A Functional decorator to enable authorization and authentication.
  * @param handler The handler to add auth to.
- * @param options Options for the authorization and authentication.
+ * @param options - Optional settings for authentication and authorization.
+ *   - `admin` (default: `false`):
+ *          When set to `true`, the route will only allow access to authenticated users with admin privileges.
+ *   - `optional` (default: `true`):
+ *          When set to `true`, the route allows unauthenticated requests.
+ *          If authentication fails or is missing, `req.user` will be set to `null`.
  * @returns A modified handler with authorization and authentication implemented as specified by options.
  */
 export function withAuth<T>(
@@ -44,11 +54,7 @@ export function withAuth<T>(
                 isAdmin: decoded.isAdmin,
             };
 
-
-            await handler(
-                authReq,
-                res as NextApiResponse<T>
-            );
+            await handler(authReq, res as NextApiResponse<T>);
         } catch (error) {
             if (error instanceof jwt.TokenExpiredError) {
                 res.status(401).json({ error: "Access token expired" });
@@ -58,5 +64,46 @@ export function withAuth<T>(
             }
             return;
         }
+    };
+}
+
+/**
+ * A Functional decorator to optionally enable authorization and authentication.
+ * @param handler The handler to add optional auth to.
+ * @param options Options for the authorization and authentication.
+ * @returns A modified handler with optional authorization and authentication.
+ */
+export function withOptionalAuth<T>(
+    handler: OptionallyAuthenticatedHandler<T>
+): NextApiHandler<T | { error: string }> {
+    return async (
+        req: NextApiRequest,
+        res: NextApiResponse<T | { error: string }>
+    ): Promise<void> => {
+        let user = null;
+
+        const authHeader = req.headers.authorization;
+
+        if (authHeader && authHeader.startsWith("Bearer ")) {
+            const token = authHeader.substring(7); // Remove 'Bearer ' from 'Bearer token'
+
+            try {
+                const decoded = jwt.verify(token, JWT_SECRET) as any;
+
+                user = {
+                    userId: decoded.id,
+                    isAdmin: decoded.isAdmin,
+                };
+            } catch (error) {
+                console.log(error);
+                // Token is invalid or expired, user remains null
+            }
+        }
+
+        const authReq = req as OptionallyAuthenticatedRequest;
+        authReq.user = user;
+
+        // Call the handler
+        await handler(authReq, res as NextApiResponse<T>);
     };
 }

--- a/src/auth/utils.ts
+++ b/src/auth/utils.ts
@@ -36,7 +36,20 @@ export interface AuthenticatedRequest extends NextApiRequest {
     };
 }
 
+// OptionallyAuthenticatedRequest's are passed on to handlers where auth is optional.
+export interface OptionallyAuthenticatedRequest extends NextApiRequest {
+    user: {
+        userId: string;
+        isAdmin: boolean;
+    } | null;
+}
+
 export type AuthenticatedHandler<T> = (
     req: AuthenticatedRequest,
+    res: NextApiResponse<T>
+) => unknown | Promise<unknown>;
+
+export type OptionallyAuthenticatedHandler<T> = (
+    req: OptionallyAuthenticatedRequest,
     res: NextApiResponse<T>
 ) => unknown | Promise<unknown>;


### PR DESCRIPTION
**Summary**

Users now see hidden comments iff they authored it. The `GET /api/comments` endpoint can still be queried without auth as it was previously, but adding an authorization allows for the hidden comments to be seen for authors. This is implemented by adding a withOptionalAuth middleware.

**Testing**

Tested using the existing postman request and it seems to work.

Issues to be closed by this PR: 
- https://github.com/Scriptorium-CSC309/web/issues/81
