### PR TITLE
Fix inconsistency between report comment and report blogposts

### DIFF
--- a/src/blogposts/[id]/report-blogpost.ts
+++ b/src/blogposts/[id]/report-blogpost.ts
@@ -1,0 +1,94 @@
+import type { NextApiResponse } from "next";
+import prisma from "@/prisma";
+import Joi from "joi";
+import { withAuth } from "@/src/auth/middleware";
+import { AuthenticatedRequest } from "../../auth/utils";
+import { SERVER_ERROR_MSG } from "@/src/constants";
+
+type Error = {
+    error: string;
+};
+
+type SuccessResponse = {
+    message: string;
+};
+
+const MIN_EXPLANATION_LENGTH = 10;
+
+const querySchema = Joi.object({
+    id: Joi.number().integer().required(),
+});
+
+const bodySchema = Joi.object({
+    explanation: Joi.string().min(MIN_EXPLANATION_LENGTH).required(),
+});
+
+async function handler(
+    req: AuthenticatedRequest,
+    res: NextApiResponse<SuccessResponse | Error>
+) {
+    if (req.method !== "POST") {
+        return res.status(405).json({ error: "Method not allowed" });
+    }
+
+    // Validate the 'id' parameter from the route query
+    const { value: params, error: paramsError } = querySchema.validate(
+        req.query,
+        { convert: true }
+    );
+    if (paramsError) {
+        return res.status(400).json({ error: paramsError.details[0].message });
+    }
+
+    // Validate the 'explanation' parameter from the body
+    const { value: body, error: bodyError } = bodySchema.validate(req.body);
+    if (bodyError) {
+        return res.status(400).json({ error: bodyError.details[0].message });
+    }
+
+    const { id } = params;
+    const { explanation } = body;
+    const userId = Number(req.user.userId);
+
+    try {
+        // Verify the blog post exists
+        const blogPost = await prisma.blogPost.findUnique({
+            where: { id: id },
+        });
+
+        if (!blogPost) {
+            return res.status(404).json({ error: "Blog post not found" });
+        }
+
+        // Check if the user has already reported this blog post
+        const existingReport = await prisma.blogPostReport.findFirst({
+            where: {
+                reporterId: userId,
+                blogPostId: id,
+            },
+        });
+
+        if (existingReport) {
+            return res
+                .status(409)
+                .json({ error: "You have already reported this blog post" });
+        }
+
+        // Create a new report for the blog post
+        await prisma.blogPostReport.create({
+            data: {
+                reporterId: userId,
+                blogPostId: id,
+                explanation: explanation,
+            },
+        });
+
+        return res.status(201).json({
+            message: "Blog post reported successfully",
+        });
+    } catch (err) {
+        return res.status(500).json({ error: SERVER_ERROR_MSG });
+    }
+}
+
+export default withAuth(handler);


### PR DESCRIPTION
1. Added duplicate report check for blog posts
2. Added proper validation using JoiThis PR addresses the inconsistency between report comment and report blogpost functionality. Specifically:1. Added duplicate report check for blog posts   - Users can no longer report the same blog post multiple times   - Returns 409 status code for duplicate reports2. Added proper validation using Joi   - Added validation for blog post ID   - Added validation for explanation field3. Using correct status codes (201 for creation)   - Changed from 200 to 201 for successful creation   - Matches comment report behavior4. Added minimum explanation length validation   - Enforces 10 character minimum length   - Consistent with comment report requirements5. Reorganized code structure to match comments implementation   - Moved logic to src/blogposts/[id]/report-blogpost.ts   - Follows same pattern as comment reports6. Updated swagger documentation   - Added minimum length requirement to explanation field   - Updated response codes to match new behavior   - Added 409 status code documentationThese changes ensure consistent behavior between blog post and comment reporting features, improving the overall user experience and maintainability of the codebase.Fixes #69
3. Using correct status codes (201 for creation)
4. Added minimum explanation length validation
5. Reorganized code structure to match comments implementation
6. Updated swagger documentation

Fixes #69

**Summary**

Add a short description of the PR

**Review Notes**

Include any comments for the reviewers of this PR. For example, something you want reviewed closely.
Delete this section if not needed.

**Testing**

Add a detailed description of the testing performed. Include screenshots or videos if needed.

- Test 1: ...


- Test 2: ...

Issues to be closed by this PR: 
- https://github.com/Scriptorium-CSC309/web/issues/sample-issue
