### PR TITLE
Dockerized Python and Java code execution

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -20,3 +20,4 @@ ADMIN_PHONE_NUMBER="0000000000"
 
 # the tag of the built images, used by code execution logic
 PYTHON_IMAGE_TAG="python-executor:3.10"
+OPENJDK_IMAGE_TAG="java-executor:20"

--- a/.env.template
+++ b/.env.template
@@ -17,3 +17,6 @@ ADMIN_EMAIL="adminemail@example.com"
 ADMIN_PASSWORD="ADMIN_PASSWORD"
 ADMIN_NAME="ADMIN_NAME"
 ADMIN_PHONE_NUMBER="0000000000"
+
+# the tag of the built images, used by code execution logic
+PYTHON_IMAGE_TAG="python-executor:3.10"

--- a/docker/java.Dockerfile
+++ b/docker/java.Dockerfile
@@ -1,0 +1,6 @@
+# java-executor:20
+
+FROM openjdk:20-slim
+
+# Open the sh shell on first entry
+ENTRYPOINT ["sh", "-c"]  

--- a/docker/python.Dockerfile
+++ b/docker/python.Dockerfile
@@ -2,8 +2,6 @@
 
 FROM python:3.10-slim
 
-WORKDIR /usr/src/app
-
 # Create a non-root user for security
 RUN adduser --disabled-password --gecos '' appuser
 

--- a/docker/python.Dockerfile
+++ b/docker/python.Dockerfile
@@ -1,0 +1,11 @@
+# python-executor:3.10
+
+FROM python:3.10-slim
+
+WORKDIR /usr/src/app
+
+# Create a non-root user for security
+RUN adduser --disabled-password --gecos '' appuser
+
+# Switch to the non-root user
+USER appuser

--- a/pages/api/execute/index.ts
+++ b/pages/api/execute/index.ts
@@ -28,10 +28,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
  *                 type: string
  *                 description: (Optional) The standard input to be provided to the code during execution.
  *                 example: "input data"
- *               timeout:
- *                 type: integer
- *                 description: (Optional) The maximum time allowed for code execution, specified in milliseconds.
- *                 example: 5000
  *     responses:
  *       200:
  *         description: Code executed successfully
@@ -138,7 +134,7 @@ export default async function handler(
     req: NextApiRequest,
     res: NextApiResponse<ResponseData>
 ) {
-    let { language, code, stdin, timeout } = req.body;
+    let { language, code, stdin } = req.body;
     let executor = ExecutorFactory.fromLanguage(language);
     if (!executor) {
         res.status(400).json({ message: "The language is not supported." });
@@ -148,7 +144,6 @@ export default async function handler(
     const execution_result = await executor.execute({
         code: code,
         stdin: stdin,
-        timeout: timeout,
     });
     res.status(200).json(execution_result);
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,4 +12,4 @@ export const MAX_PAGES = 100;
 export const PAGE_SIZE = 10;
 export const SERVER_ERROR_MSG = "Internal Server Error";
 export const EXECUTION_MEMORY_LIMIT = 50; // in MB
-export const EXECUTION_TIME_LIMIT = 60; // in seconds
+export const EXECUTION_TIME_LIMIT = 10; // in seconds

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,5 @@ export const MAX_PAGE_SIZE = 100;
 export const MAX_PAGES = 100;
 export const PAGE_SIZE = 10;
 export const SERVER_ERROR_MSG = "Internal Server Error";
+export const EXECUTION_MEMORY_LIMIT = 50; // in MB
+export const EXECUTION_TIME_LIMIT = 60; // in seconds

--- a/src/execute/executor.ts
+++ b/src/execute/executor.ts
@@ -14,12 +14,6 @@ export interface ExecutionOptions {
      * Useful for programs that require user input.
      */
     stdin?: string;
-
-    /**
-     * (Optional) The maximum time allowed for code execution, specified in milliseconds.
-     * If the execution exceeds this time, it should be terminated to prevent indefinite runs.
-     */
-    timeout?: number; // in milliseconds (not needed for part 1)
 }
 
 /**

--- a/src/execute/python-executor.ts
+++ b/src/execute/python-executor.ts
@@ -1,3 +1,4 @@
+import { EXECUTION_MEMORY_LIMIT, EXECUTION_TIME_LIMIT } from "../constants";
 import { ExecutionOptions, ExecutionResult, Executor } from "./executor";
 import {
     cleanupFile,
@@ -6,13 +7,27 @@ import {
     spawnHelper,
 } from "./utils";
 
+const PYTHON_IMAGE_TAG = process.env.PYTHON_IMAGE_TAG!;
+
 export class PythonExecutor implements Executor {
     async execute(options: ExecutionOptions): Promise<ExecutionResult> {
-        const tempFileName = getUniqueFileName() + ".py";
+        const uniqueId = getUniqueFileName();
+        const tempFileName = uniqueId + ".py";
         const tempFilePath = await createTempFile(tempFileName, options.code);
 
+        const dockerArgs = [
+            'run',
+            '-i',  // Interactivity is needed for providing stdin
+            '--rm',  // Automatically remove the container after execution
+            '--ulimit', `cpu=${EXECUTION_TIME_LIMIT}`,  // Limit to EXECUTION_TIME_LIMIT of CPU time
+            '--memory', `${EXECUTION_MEMORY_LIMIT}m`, // Limit memory to EXECUTION_MEMORY_LIMIT MB
+            '--mount', `type=bind,source=${tempFilePath},target=/code.py,readonly`,  
+            PYTHON_IMAGE_TAG,
+            'python3', '/code.py'  // command to execute in the shell after the image is built
+        ];
+
         const { stdout, stderr } = await spawnHelper(
-            { command: "python3", args: [tempFilePath] },
+            { command: "docker", args: dockerArgs },
             options.stdin
         );
 

--- a/src/execute/python-executor.ts
+++ b/src/execute/python-executor.ts
@@ -26,10 +26,17 @@ export class PythonExecutor implements Executor {
             'python3', '/code.py'  // command to execute in the shell after the image is built
         ];
 
-        const { stdout, stderr } = await spawnHelper(
+        let { stdout, stderr, code } = await spawnHelper(
             { command: "docker", args: dockerArgs },
             options.stdin
         );
+
+
+        // TODO: this approach works unless code itself exits with status 137. Think about what to do then 
+        const FORCED_DOCKER_EXIT_CODE = 137;
+        if (code == FORCED_DOCKER_EXIT_CODE) {   
+            stderr += "process exited with code 137. Most likely due to exceeding memory or CPU time limit."
+        }
 
         try {
             await cleanupFile(tempFilePath);


### PR DESCRIPTION
**Summary**

Python and Java code execution are now dockerized with time and memory limit enforced in their execution environment.

**Review Notes**

We previously asked the user to specify a timeout when sending an execute request, which was wrong according to this user story in hindsight. 

> As a visitor, I want the **system** to enforce a time and memory limit on code execution so that infinite loops or long-running processes are automatically terminated.

So, I removed the timeout field from the executor input interface.
 
**Testing**

To setup your local machine for testing, first ensure you have docker on your computer. Then, follow the below steps:
- The `.env.template` has two new additions, set these up in your `.env`. 
- Once setup, run the following terminal commands in the base directory of the cloned repository, where <OPENJDK_IMAGE_TAG> and <PYTHON_IMAGE_TAG> are replaced with their values from your `.env`
`docker buildx build --tag <OPENJDK_IMAGE_TAG> -f ./docker/java.Dockerfile ./docker`
`docker buildx build --tag <PYTHON_IMAGE_TAG> -f ./docker/python.Dockerfile ./docker`

This setup will get less painful when soon when the we dockerize the whole app for deployment and update the startup and run scripts.

Tested with existing tests in postman and added new tests for testing timeout for Python and Java. They seem to work.

Issues to be closed by this PR: 
- https://github.com/Scriptorium-CSC309/web/issues/99